### PR TITLE
Fixed Dockerfile based build timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     build-essential \
     bzip2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN pip3 install pip --upgrade
 RUN pip3 install cython aicrowd_api timeout_decorator \
   numpy \
   matplotlib \
-  aicrowd-repo2docker 
+  aicrowd-repo2docker \
+  pillow
 RUN pip3 install git+https://github.com/AIcrowd/coco.git#subdirectory=PythonAPI
 RUN pip3 install tensorflow-gpu
 


### PR DESCRIPTION
```
Setting up tzdata (2019c-0ubuntu0.18.04) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------

Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.

  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area:
```

The docker build is getting stuck forever.
Above is fixed via this commit.