### PR TITLE
Bug resolve for initializing the MMDetection pre-trained models

### DIFF
--- a/predict_mmdetection.py
+++ b/predict_mmdetection.py
@@ -85,11 +85,22 @@ class MMDetectionPredictor(FoodChallengePredictor):
         self.cfg.data.samples_per_gpu = 1
         self.cfg.data.workers_per_gpu = 2
         self.cfg.model.pretrained = None
+        # For RFP based models we have another pretrained to set to None
+        if self.cfg.model.get('neck'):
+            if isinstance(self.cfg.model.neck, list):
+                for neck_cfg in self.cfg.model.neck:
+                    if neck_cfg.get('rfp_backbone'):
+                        if neck_cfg.rfp_backbone.get('pretrained'):
+                            neck_cfg.rfp_backbone.pretrained = None
+            elif self.cfg.model.neck.get('rfp_backbone'):
+                if self.cfg.model.neck.rfp_backbone.get('pretrained'):
+                    self.cfg.model.neck.rfp_backbone.pretrained = None
+
         self.cfg.data.test.test_mode = True
         self.cfg.data.test.ann_file = self.test_predictions_file.name
         self.cfg.data.test.img_prefix = self.test_data_path
 
-        self.model = init_detector(self.cfg_name, self.checkpoint_name, device="cuda:0")
+        self.model = init_detector(self.cfg, self.checkpoint_name, device="cuda:0")
 
         fp16_cfg = self.cfg.get("fp16", None)
         if fp16_cfg is not None:


### PR DESCRIPTION
Hello,

This pull request aims in resolving a bug (initializing the pre-trained MMDetection model).
**Bug 1:** Although `init_detector()` accepts both configuration file path or object, however, in `prediction_setup()` function of `predict_mmdetection.py` file you are setting the configuration variable but initializing the model with the configuration file path. This way you are nullifying the assignments in the configuration object. 
**Solution:** Instead of passing the configuration file path, pass the configuration object. 

**Bug 2:** FPN based model requires pre-trained weights only in `backbone`, whereas RFP-based models use an additional backbone in `neck` for which you need to set `pretrained=None` otherwise it will download the respective model during evaluation. Downloading the weights is not a problem but we have a time limit in `prediction_setup()`. 
Error during evaluation: 
```
evaluator.utils.TimeoutException: Prediction timed out!
```
**Solution:** Set `pretrained=None` for the model which uses the RFP backbone. 

This PR mitigates these problems. Please do let me know if there's any issue. 
